### PR TITLE
Refatoração para melhor organização do código

### DIFF
--- a/src/br/edu/insper/desagil/alfandega/Alfandega.java
+++ b/src/br/edu/insper/desagil/alfandega/Alfandega.java
@@ -12,11 +12,11 @@ public class Alfandega {
 		this.itensTarifados = new ArrayList<>();
 	}
 
-	public void declara(Item item) {
+	public void declaraItem(Item item) {
 		this.itens.add(item);
 	}
 
-	public void declara(ItemTarifado itemTarifado) {
+	public void declaraItemTarifado(ItemTarifado itemTarifado) {
 		this.itensTarifados.add(itemTarifado);
 	}
 

--- a/src/br/edu/insper/desagil/alfandega/ItemTarifado.java
+++ b/src/br/edu/insper/desagil/alfandega/ItemTarifado.java
@@ -1,28 +1,11 @@
 package br.edu.insper.desagil.alfandega;
 
-public class ItemTarifado {
-	private String nome;
-	private double valor;
-	private double rate;
+public class ItemTarifado extends Item{
 	private double tarifa;
-
+	
 	public ItemTarifado(String nome, double valor, double rate, double tarifa) {
-		this.nome = nome;
-		this.valor = valor;
-		this.rate = rate;
+		super(nome, valor, rate);
 		this.tarifa = tarifa;
-	}
-
-	public String getNome() {
-		return this.nome;
-	}
-
-	public double getValor() {
-		return this.valor;
-	}
-
-	public double getRate() {
-		return this.rate;
 	}
 
 	public double getTarifa() {

--- a/test/br/edu/insper/desagil/alfandega/AlfandegaTest.java
+++ b/test/br/edu/insper/desagil/alfandega/AlfandegaTest.java
@@ -17,112 +17,112 @@ class AlfandegaTest {
 
 	@Test
 	void testA() {
-		alfandega.declara(new Item("a", 25.0, 5.12));
-		alfandega.declara(new Item("b", 50.0, 6.19));
+		alfandega.declaraItem(new Item("a", 25.0, 5.12));
+		alfandega.declaraItem(new Item("b", 50.0, 6.19));
 		assertEquals(437.5, alfandega.getTotalDeclarado(), DELTA);
 		assertEquals(4.38, alfandega.getTotalDevido(), DELTA);
 	}
 
 	@Test
 	void testB() {
-		alfandega.declara(new Item("a", 50.0, 5.12));
-		alfandega.declara(new Item("b", 25.0, 6.19));
+		alfandega.declaraItem(new Item("a", 50.0, 5.12));
+		alfandega.declaraItem(new Item("b", 25.0, 6.19));
 		assertEquals(410.75, alfandega.getTotalDeclarado(), DELTA);
 		assertEquals(4.11, alfandega.getTotalDevido(), DELTA);
 	}
 
 	@Test
 	void testC() {
-		alfandega.declara(new Item("a", 25.0, 5.12));
-		alfandega.declara(new ItemTarifado("b", 50.0, 6.19, 0.6));
+		alfandega.declaraItem(new Item("a", 25.0, 5.12));
+		alfandega.declaraItemTarifado(new ItemTarifado("b", 50.0, 6.19, 0.6));
 		assertEquals(437.5, alfandega.getTotalDeclarado(), DELTA);
 		assertEquals(186.98, alfandega.getTotalDevido(), DELTA);
 	}
 
 	@Test
 	void testD() {
-		alfandega.declara(new Item("a", 50.0, 5.12));
-		alfandega.declara(new ItemTarifado("b", 25.0, 6.19, 0.6));
+		alfandega.declaraItem(new Item("a", 50.0, 5.12));
+		alfandega.declaraItemTarifado(new ItemTarifado("b", 25.0, 6.19, 0.6));
 		assertEquals(410.75, alfandega.getTotalDeclarado(), DELTA);
 		assertEquals(95.41, alfandega.getTotalDevido(), DELTA);
 	}
 
 	@Test
 	void testE() {
-		alfandega.declara(new ItemTarifado("a", 25.0, 5.12, 0.6));
-		alfandega.declara(new Item("b", 50.0, 6.19));
+		alfandega.declaraItemTarifado(new ItemTarifado("a", 25.0, 5.12, 0.6));
+		alfandega.declaraItem(new Item("b", 50.0, 6.19));
 		assertEquals(437.5, alfandega.getTotalDeclarado(), DELTA);
 		assertEquals(79.9, alfandega.getTotalDevido(), DELTA);
 	}
 
 	@Test
 	void testF() {
-		alfandega.declara(new ItemTarifado("a", 50.0, 5.12, 0.6));
-		alfandega.declara(new Item("b", 25.0, 6.19));
+		alfandega.declaraItemTarifado(new ItemTarifado("a", 50.0, 5.12, 0.6));
+		alfandega.declaraItem(new Item("b", 25.0, 6.19));
 		assertEquals(410.75, alfandega.getTotalDeclarado(), DELTA);
 		assertEquals(155.15, alfandega.getTotalDevido(), DELTA);
 	}
 
 	@Test
 	void testG() {
-		alfandega.declara(new ItemTarifado("a", 25.0, 5.12, 0.6));
-		alfandega.declara(new ItemTarifado("b", 50.0, 6.19, 0.6));
+		alfandega.declaraItemTarifado(new ItemTarifado("a", 25.0, 5.12, 0.6));
+		alfandega.declaraItemTarifado(new ItemTarifado("b", 50.0, 6.19, 0.6));
 		assertEquals(437.5, alfandega.getTotalDeclarado(), DELTA);
 		assertEquals(262.5, alfandega.getTotalDevido(), DELTA);
 	}
 
 	@Test
 	void testH() {
-		alfandega.declara(new ItemTarifado("a", 50.0, 5.12, 0.6));
-		alfandega.declara(new ItemTarifado("b", 25.0, 6.19, 0.6));
+		alfandega.declaraItemTarifado(new ItemTarifado("a", 50.0, 5.12, 0.6));
+		alfandega.declaraItemTarifado(new ItemTarifado("b", 25.0, 6.19, 0.6));
 		assertEquals(410.75, alfandega.getTotalDeclarado(), DELTA);
 		assertEquals(246.45, alfandega.getTotalDevido(), DELTA);
 	}
 
 	@Test
 	void testI() {
-		alfandega.declara(new ItemTarifado("a", 25.0, 5.12, 0.8));
-		alfandega.declara(new ItemTarifado("b", 50.0, 6.19, 0.8));
+		alfandega.declaraItemTarifado(new ItemTarifado("a", 25.0, 5.12, 0.8));
+		alfandega.declaraItemTarifado(new ItemTarifado("b", 50.0, 6.19, 0.8));
 		assertEquals(437.5, alfandega.getTotalDeclarado(), DELTA);
 		assertEquals(350.0, alfandega.getTotalDevido(), DELTA);
 	}
 
 	@Test
 	void testJ() {
-		alfandega.declara(new ItemTarifado("a", 50.0, 5.12, 0.8));
-		alfandega.declara(new ItemTarifado("b", 25.0, 6.19, 0.8));
+		alfandega.declaraItemTarifado(new ItemTarifado("a", 50.0, 5.12, 0.8));
+		alfandega.declaraItemTarifado(new ItemTarifado("b", 25.0, 6.19, 0.8));
 		assertEquals(410.75, alfandega.getTotalDeclarado(), DELTA);
 		assertEquals(328.6, alfandega.getTotalDevido(), DELTA);
 	}
 
 	@Test
 	void testK() {
-		alfandega.declara(new ItemTarifado("a", 25.0, 5.12, 0.6));
-		alfandega.declara(new ItemTarifado("b", 50.0, 6.19, 0.8));
+		alfandega.declaraItemTarifado(new ItemTarifado("a", 25.0, 5.12, 0.6));
+		alfandega.declaraItemTarifado(new ItemTarifado("b", 50.0, 6.19, 0.8));
 		assertEquals(437.5, alfandega.getTotalDeclarado(), DELTA);
 		assertEquals(324.4, alfandega.getTotalDevido(), DELTA);
 	}
 
 	@Test
 	void testL() {
-		alfandega.declara(new ItemTarifado("a", 50.0, 5.12, 0.6));
-		alfandega.declara(new ItemTarifado("b", 25.0, 6.19, 0.8));
+		alfandega.declaraItemTarifado(new ItemTarifado("a", 50.0, 5.12, 0.6));
+		alfandega.declaraItemTarifado(new ItemTarifado("b", 25.0, 6.19, 0.8));
 		assertEquals(410.75, alfandega.getTotalDeclarado(), DELTA);
 		assertEquals(277.4, alfandega.getTotalDevido(), DELTA);
 	}
 
 	@Test
 	void testM() {
-		alfandega.declara(new ItemTarifado("a", 25.0, 5.12, 0.8));
-		alfandega.declara(new ItemTarifado("b", 50.0, 6.19, 0.6));
+		alfandega.declaraItemTarifado(new ItemTarifado("a", 25.0, 5.12, 0.8));
+		alfandega.declaraItemTarifado(new ItemTarifado("b", 50.0, 6.19, 0.6));
 		assertEquals(437.5, alfandega.getTotalDeclarado(), DELTA);
 		assertEquals(288.1, alfandega.getTotalDevido(), DELTA);
 	}
 
 	@Test
 	void testN() {
-		alfandega.declara(new ItemTarifado("a", 50.0, 5.12, 0.8));
-		alfandega.declara(new ItemTarifado("b", 25.0, 6.19, 0.6));
+		alfandega.declaraItemTarifado(new ItemTarifado("a", 50.0, 5.12, 0.8));
+		alfandega.declaraItemTarifado(new ItemTarifado("b", 25.0, 6.19, 0.6));
 		assertEquals(410.75, alfandega.getTotalDeclarado(), DELTA);
 		assertEquals(297.65, alfandega.getTotalDevido(), DELTA);
 	}


### PR DESCRIPTION
### Parte 1:
A classe "_ItemTarifado_" agora faz herança (_extends_) da classe "_Item_" para evitar repetições e, consequentemente, melhorando a abstração, já que o um _itemTarifado_ não é nada mais do que um item normal, porém com tarifa. Além disso, existiam dois métodos com o mesmo nome "_declara_" causando uma má coesão, já que realizavam diferentes coisas, porém possuíam o mesmo nome. Para resolver isso, mudei o nome do método que declarava _Item_ para "_declaraItem_" e o método que declarava _itemTarifado_ para "_declaraItemTarifado_". 